### PR TITLE
Added fallback to master when detected branch name is unknown

### DIFF
--- a/lib/php/libsdk/SDK/Config.php
+++ b/lib/php/libsdk/SDK/Config.php
@@ -180,7 +180,9 @@ class Config
 	public static function setCurrentBranchName(string $name) : void
 	{/*{{{*/
 		if (!array_key_exists($name, self::getKnownBranches())) {
-			throw new Exception("Unsupported branch '$name'");
+			fwrite(STDERR, "Unsupported branch '$name'. Falling back to 'master'.");
+
+			$name = 'master';
 		}
 
 		self::$currentBranchName = $name;


### PR DESCRIPTION
This addresses #11. It seems this would not happen if `git.exe` is detected on the path, but in case it isn't, this supports the case where git is not available.