### PR TITLE
Added forward compatibility for PHP 8.1+

### DIFF
--- a/bin/phpsdk_deps.bat
+++ b/bin/phpsdk_deps.bat
@@ -13,4 +13,3 @@ if "%PHP_SDK_PHP_CMD%"=="" (
 call %PHP_SDK_PHP_CMD% %PHP_SDK_BIN_PATH%\phpsdk_deps.php %*
 
 exit /b %errorlevel%
-

--- a/lib/php/libsdk/SDK/Config.php
+++ b/lib/php/libsdk/SDK/Config.php
@@ -197,7 +197,7 @@ class Config
 		}
 
 		/* Try to figure out the branch. The worky scenarios are
-			- CWD is in php-src 
+			- CWD is in php-src
 			- phpize is on the path
 			FIXME for the dev package, there should be a php-config utility
 		 */
@@ -230,12 +230,12 @@ class Config
 			/* Verify that we use an available branch name. Master has some
 				version, but no dedicated series. For master, it rather
 				makes sense to use master as branch name. */
-			$git = trim(shell_exec("where git.exe"));
+			$git = trim((string)shell_exec("where git.exe"));
 			if ($git && is_dir(".git")) {
 				$cmd = "\"$git\" branch";
 
 				$ret = trim(shell_exec($cmd));
-				if (preg_match_all(",\*\s+master,", $ret) > 0) {	
+				if (preg_match_all(",\*\s+master,", $ret) > 0) {
 					$branch = "master";
 				}
 			}
@@ -250,7 +250,7 @@ class Config
 			$branch = self::guessCurrentBranchName();
 			self::setCurrentBranchName($branch);
 		}
-	
+
 		return self::$currentBranchName;
 	}/*}}}*/
 
@@ -313,7 +313,7 @@ class Config
 			throw new Exception("Failed to find config with arch '" . self::getCurrentArchName() . "'");
 		}
 
-		return $ret; 
+		return $ret;
 	}/*}}}*/
 
 	public static function getSdkNugetFeedUrl() : string
@@ -368,7 +368,7 @@ class Config
 				self::setDepsLocalPath($tmp);
 			}
 		}
-		
+
 		if (NULL == self::$depsLocalPath) {
 			$tmp = realpath("../deps");
 			if (is_dir($tmp)) {


### PR DESCRIPTION
When the `shell_exec` call fails, it returns `null`. Passing `null` to `trim()`, which expects a string, is deprecated since PHP 8.1. I understand we're bundling PHP 8.0 at present, but this is just a forward compatibility change for when it's upgraded later.

As a bonus, removed some trailing whitespace.