### PR TITLE
Declare called methods in interfaces

### DIFF
--- a/lib/php/libsdk/SDK/Build/PGO/Interfaces/PHP.php
+++ b/lib/php/libsdk/SDK/Build/PGO/Interfaces/PHP.php
@@ -13,4 +13,6 @@ interface PHP
 	public function down(bool $force = false) : void;
 	public function getVersion(bool $short = false) : string;
 	public function getExeFilename() : string;
+	public function getRootDir() : string;
+	public function getExtRootDir() : string;
 }

--- a/lib/php/libsdk/SDK/Build/PGO/Interfaces/TrainingCase.php
+++ b/lib/php/libsdk/SDK/Build/PGO/Interfaces/TrainingCase.php
@@ -8,7 +8,7 @@ use SDK\Build\PGO\Tool\PackageWorkman;
 
 interface TrainingCase
 {
-	public function __construct(PGOConfig $conf, ?Server $srv_http, ?Server\DB $srv_db);
+	public function __construct(PGOConfig $conf, ?Server\HTTP $srv_http, ?Server\DB $srv_db);
 
 	/* Name of the training case, usually should be same as dirname and namespace. */
 	public function getName() : string;
@@ -24,4 +24,8 @@ interface TrainingCase
 
 	/* Get training type, it's like "web", "cli", etc.*/
 	public function getType() : string;
+
+	public function getJobFilename() : string;
+
+	public function httpStatusOk(int $status) : bool;
 }

--- a/pgo/cases/drupal/TrainingCaseHandler.php
+++ b/pgo/cases/drupal/TrainingCaseHandler.php
@@ -14,7 +14,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var string */
 	protected $base;
 
-	/** @var ?Interfaces\Server $nginx */
+	/** @var ?Interfaces\Server\HTTP $nginx */
 	protected $nginx;
 
 	/** @var mixed */
@@ -23,7 +23,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var int */
 	protected $max_runs = 8;
 
-	public function __construct(Config $conf, ?Interfaces\Server $nginx, ?Interfaces\Server\DB $maria)
+	public function __construct(Config $conf, ?Interfaces\Server\HTTP $nginx, ?Interfaces\Server\DB $maria)
 	{
 		if (!$nginx) {
 			throw new Exception("Invalid NGINX object");

--- a/pgo/cases/joomla/TrainingCaseHandler.php
+++ b/pgo/cases/joomla/TrainingCaseHandler.php
@@ -14,7 +14,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var string */
 	protected $base;
 
-	/** @var ?Interfaces\Server $nginx */
+	/** @var ?Interfaces\Server\HTTP $nginx */
 	protected $nginx;
 
 	/** @var mixed */
@@ -26,7 +26,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var int */
 	protected $max_runs = 4;
 
-	public function __construct(Config $conf, ?Interfaces\Server $nginx, ?Interfaces\Server\DB $maria)
+	public function __construct(Config $conf, ?Interfaces\Server\HTTP $nginx, ?Interfaces\Server\DB $maria)
 	{
 		if (!$nginx) {
 			throw new Exception("Invalid NGINX object");

--- a/pgo/cases/mediawiki/TrainingCaseHandler.php
+++ b/pgo/cases/mediawiki/TrainingCaseHandler.php
@@ -14,7 +14,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var string */
 	protected $base;
 
-	/** @var ?Interfaces\Server $nginx */
+	/** @var ?Interfaces\Server\HTTP $nginx */
 	protected $nginx;
 
 	/** @var mixed */
@@ -23,7 +23,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var int */
 	protected $max_runs = 4;
 
-	public function __construct(Config $conf, ?Interfaces\Server $nginx, ?Interfaces\Server\DB $srv_db)
+	public function __construct(Config $conf, ?Interfaces\Server\HTTP $nginx, ?Interfaces\Server\DB $srv_db)
 	{
 		if (!$nginx) {
 			throw new Exception("Invalid NGINX object");

--- a/pgo/cases/pgo01org/TrainingCaseHandler.php
+++ b/pgo/cases/pgo01org/TrainingCaseHandler.php
@@ -14,7 +14,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var string */
 	protected $base;
 
-	/** @var ?Interfaces\Server $nginx */
+	/** @var ?Interfaces\Server\HTTP $nginx */
 	protected $nginx;
 
 	/** @var ?Interfaces\Server\DB */
@@ -26,7 +26,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var int */
 	protected $max_runs = 12;
 
-	public function __construct(Config $conf, ?Interfaces\Server $nginx, ?Interfaces\Server\DB $maria)
+	public function __construct(Config $conf, ?Interfaces\Server\HTTP $nginx, ?Interfaces\Server\DB $maria)
 	{
 		if (!$nginx) {
 			throw new Exception("Invalid NGINX object");

--- a/pgo/cases/symfony_demo/TrainingCaseHandler.php
+++ b/pgo/cases/symfony_demo/TrainingCaseHandler.php
@@ -14,7 +14,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var string */
 	protected $base;
 
-	/** @var ?Interfaces\Server $nginx */
+	/** @var ?Interfaces\Server\HTTP $nginx */
 	protected $nginx;
 
 	/** @var mixed */
@@ -23,7 +23,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var int */
 	protected $max_runs = 4;
 
-	public function __construct(Config $conf, ?Interfaces\Server $nginx, ?Interfaces\Server\DB $srv_db)
+	public function __construct(Config $conf, ?Interfaces\Server\HTTP $nginx, ?Interfaces\Server\DB $srv_db)
 	{
 		if (!$nginx) {
 			throw new Exception("Invalid NGINX object");

--- a/pgo/cases/symfony_demo_pdo_mysql/TrainingCaseHandler.php
+++ b/pgo/cases/symfony_demo_pdo_mysql/TrainingCaseHandler.php
@@ -14,7 +14,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var string */
 	protected $base;
 
-	/** @var ?Interfaces\Server $nginx */
+	/** @var ?Interfaces\Server\HTTP $nginx */
 	protected $nginx;
 
 	/** @var ?Interfaces\Server\DB */
@@ -26,7 +26,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var int */
 	protected $max_runs = 4;
 
-	public function __construct(Config $conf, ?Interfaces\Server $nginx, ?Interfaces\Server\DB $srv_db)
+	public function __construct(Config $conf, ?Interfaces\Server\HTTP $nginx, ?Interfaces\Server\DB $srv_db)
 	{
 		if (!$nginx) {
 			throw new Exception("Invalid NGINX object");

--- a/pgo/cases/wordpress/TrainingCaseHandler.php
+++ b/pgo/cases/wordpress/TrainingCaseHandler.php
@@ -14,7 +14,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var string */
 	protected $base;
 
-	/** @var ?Interfaces\Server $nginx */
+	/** @var ?Interfaces\Server\HTTP $nginx */
 	protected $nginx;
 
 	/** @var ?Interfaces\Server\DB */
@@ -26,7 +26,7 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 	/** @var int */
 	protected $max_runs = 4;
 
-	public function __construct(Config $conf, ?Interfaces\Server $nginx, ?Interfaces\Server\DB $maria)
+	public function __construct(Config $conf, ?Interfaces\Server\HTTP $nginx, ?Interfaces\Server\DB $maria)
 	{
 		if (!$nginx) {
 			throw new Exception("Invalid NGINX object");


### PR DESCRIPTION
The obvious advantage is that implementers of these interface know what they need to implement.  The obvious downside is that this might break existing code outside this repository.

---

Note that this is untested, mostly because there is only one working training case; I'll try to have a look at the others as soon as possible.