### PR TITLE
Update php.ini for PGO for PHP >= 8.2

### DIFF
--- a/pgo/tpl/php/php-8.2-pgo-nts-cache.ini
+++ b/pgo/tpl/php/php-8.2-pgo-nts-cache.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 zend_extension=php_opcache.dll
 opcache.memory_consumption=PHP_SDK_PGO_PHP_OPCACHE_MEMORY_CONSUMPTION

--- a/pgo/tpl/php/php-8.2-pgo-nts.ini
+++ b/pgo/tpl/php/php-8.2-pgo-nts.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;

--- a/pgo/tpl/php/php-8.2-pgo-ts-cache.ini
+++ b/pgo/tpl/php/php-8.2-pgo-ts-cache.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 zend_extension=php_opcache.dll
 opcache.memory_consumption=PHP_SDK_PGO_PHP_OPCACHE_MEMORY_CONSUMPTION

--- a/pgo/tpl/php/php-8.2-pgo-ts.ini
+++ b/pgo/tpl/php/php-8.2-pgo-ts.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;

--- a/pgo/tpl/php/php-8.3-pgo-nts-cache.ini
+++ b/pgo/tpl/php/php-8.3-pgo-nts-cache.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 zend_extension=php_opcache.dll
 opcache.memory_consumption=PHP_SDK_PGO_PHP_OPCACHE_MEMORY_CONSUMPTION

--- a/pgo/tpl/php/php-8.3-pgo-nts.ini
+++ b/pgo/tpl/php/php-8.3-pgo-nts.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;

--- a/pgo/tpl/php/php-8.3-pgo-ts-cache.ini
+++ b/pgo/tpl/php/php-8.3-pgo-ts-cache.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 zend_extension=php_opcache.dll
 opcache.memory_consumption=PHP_SDK_PGO_PHP_OPCACHE_MEMORY_CONSUMPTION

--- a/pgo/tpl/php/php-8.3-pgo-ts.ini
+++ b/pgo/tpl/php/php-8.3-pgo-ts.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;

--- a/pgo/tpl/php/php-8.4-pgo-nts-cache.ini
+++ b/pgo/tpl/php/php-8.4-pgo-nts-cache.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 zend_extension=php_opcache.dll
 opcache.memory_consumption=PHP_SDK_PGO_PHP_OPCACHE_MEMORY_CONSUMPTION

--- a/pgo/tpl/php/php-8.4-pgo-nts.ini
+++ b/pgo/tpl/php/php-8.4-pgo-nts.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;

--- a/pgo/tpl/php/php-8.4-pgo-ts-cache.ini
+++ b/pgo/tpl/php/php-8.4-pgo-ts-cache.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 zend_extension=php_opcache.dll
 opcache.memory_consumption=PHP_SDK_PGO_PHP_OPCACHE_MEMORY_CONSUMPTION

--- a/pgo/tpl/php/php-8.4-pgo-ts.ini
+++ b/pgo/tpl/php/php-8.4-pgo-ts.ini
@@ -981,7 +981,7 @@ extension=php_sqlite3.dll
 ;extension=php_tidy.dll
 ;extension=php_xmlrpc.dll
 ;extension=php_xsl.dll
-;extension=php_zip.dll
+extension=php_zip.dll
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;


### PR DESCRIPTION
ext/zip is no longer statically compiled as of PHP 8.2.0, but is needed for several setup tasks; thus we load the shared extension.