### PR TITLE
Fix, update and re-activate symfony_demo PGO training case

### DIFF
--- a/pgo/cases/symfony_demo/TrainingCaseHandler.php
+++ b/pgo/cases/symfony_demo/TrainingCaseHandler.php
@@ -47,22 +47,23 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 
 	protected function getToolFn() : string
 	{
-		return $this->conf->getToolsDir() . DIRECTORY_SEPARATOR . "symfony.phar";
+		return $this->conf->getToolsDir() . DIRECTORY_SEPARATOR . "composer.phar";
 	}
 
 	protected function setupDist() : void
 	{
 		if (!is_dir($this->conf->getCaseWorkDir($this->getName()))) {
 			echo "Setting up in '{$this->base}'\n";
+			$ver = $this->conf->getSectionItem($this->getName(), "symfony_demo_version");
 			$php = new PHP\CLI($this->conf);
-			$php->exec($this->getToolFn() . " demo " . $this->base);
+			$php->exec($this->getToolFn() . " create-project symfony/symfony-demo " . $this->base . " " . $ver);
 		}
 
 		$port = $this->getHttpPort();
 		$host = $this->getHttpHost();
 
 		$vars = array(
-			$this->conf->buildTplVarName($this->getName(), "docroot") => str_replace("\\", "/", $this->base . DIRECTORY_SEPARATOR . "web"),
+			$this->conf->buildTplVarName($this->getName(), "docroot") => str_replace("\\", "/", $this->base . DIRECTORY_SEPARATOR . "public"),
 		);
 		$tpl_fn = $this->conf->getCasesTplDir($this->getName()) . DIRECTORY_SEPARATOR . "nginx.partial.conf";
 		$this->nginx->addServer($tpl_fn, $vars);
@@ -105,8 +106,6 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 
 	public function prepareInit(Tool\PackageWorkman $pw, bool $force = false) : void
 	{
-		$url = $this->conf->getSectionItem($this->getName(), "symfony_phar_url");
-		$pw->fetch($url, $this->getToolFn(), $force);
 	}
 
 	public function init() : void

--- a/pgo/cases/symfony_demo/nginx.partial.conf
+++ b/pgo/cases/symfony_demo/nginx.partial.conf
@@ -7,10 +7,10 @@
 
         # symfony 
 	location / {
-            try_files $uri /app.php$is_args$args;
+            try_files $uri /index.php$is_args$args;
 	}
 
-	location ~ ^/app\.php(/|$) {
+	location ~ ^/index\.php(/|$) {
             fastcgi_pass   PHP_SDK_PGO_PHP_FCGI_HOST:PHP_SDK_PGO_PHP_FCGI_PORT;
 	    fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include        fastcgi_params;

--- a/pgo/cases/symfony_demo/phpsdk_pgo.json
+++ b/pgo/cases/symfony_demo/phpsdk_pgo.json
@@ -1,5 +1,5 @@
 {
-	"symfony_phar_url": "https://get.symfony.com/symfony.phar",
+	"symfony_demo_version": "v2.4.0",
 	"type": "web",
 	"srv_http": "nginx",
 	"srv_db": null


### PR DESCRIPTION
This test case had been deactivated a couple of years ago[1], because it was broken[2].  We fix it by switching to the composer installation of the Symfony demo application, update to version 2.4.0 (which is the last version supporting PHP 8.1, but apparently also runs fine with PHP 8.4), and re-activate it.

[1] <https://github.com/php/php-sdk-binary-tools/commit/7893436c79ba25c02720516a959a5fc8e3957ad3>
[2] <https://github.com/microsoft/php-sdk-binary-tools/issues/73>

---

Note that I run a full PGO build for the PHP-8.2 and the master branch only, and didn't notice any issues. This needs further testing; likely after some dependencies have been updated.