### PR TITLE
Update Nginx to 1.26.2

### DIFF
--- a/pgo/tpl/nginx/phpsdk_pgo.json
+++ b/pgo/tpl/nginx/phpsdk_pgo.json
@@ -1,5 +1,5 @@
 {
-	"pkg_url": "https://nginx.org/download/nginx-1.17.6.zip",
+	"pkg_url": "https://nginx.org/download/nginx-1.26.2.zip",
 	"host": "127.0.0.1",
 	"port": 8081
 }


### PR DESCRIPTION
That is the latest stable version, and certainly progress over Nginx 1.17.6 which has been released almost five years ago.

---

A PGO run with pgo01org and symfony_demo showed no issues.