### PR TITLE
Fix and update MariaDB installation

### DIFF
--- a/lib/php/libsdk/SDK/Build/PGO/Server/MariaDB.php
+++ b/lib/php/libsdk/SDK/Build/PGO/Server/MariaDB.php
@@ -30,7 +30,9 @@ class MariaDB extends Server implements DB
 	/** @return void */
 	protected function setupDist()
 	{
-		/* pass */
+		if (file_exists("$this->base/bin/mariadb-install-db.exe")) {
+			exec("$this->base/bin/mariadb-install-db.exe");
+		}
 	}
 
 	public function prepareInit(PackageWorkman $pw, bool $force = false) : void

--- a/pgo/tpl/mariadb/phpsdk_pgo.json
+++ b/pgo/tpl/mariadb/phpsdk_pgo.json
@@ -1,5 +1,5 @@
 {
-	"pkg_url": "https://downloads.mariadb.com/MariaDB/mariadb-10.3.22/win32-packages/mariadb-10.3.22-win32.zip",
+	"pkg_url": "https://downloads.mariadb.org/rest-api/mariadb/10.5.26/mariadb-10.5.26-winx64.zip",
 	"host": "localhost",
 	"port": 3307,
 	"user": "root",


### PR DESCRIPTION
The download URL has changed, and since MariaDB 10.3.22 is a very old relases, we update to MariaDB 10.5.26 (which is the lowest still supported branch) right away.

Since newer MariaDB apparently require to run mariadb-install-db.exe to properly set up the databases, we do this, if that executable is available.

---

Since I have tested only `phpsdk_pgo --init` so far, I'm filing this as draft PR.