### PR TITLE
Disable deprecation notices for PGO by default

### DIFF
--- a/pgo/tpl/php/php-8.4-pgo-nts-cache.ini
+++ b/pgo/tpl/php/php-8.4-pgo-nts-cache.ini
@@ -512,7 +512,7 @@ memory_limit = 128M
 ; Production Value: E_ALL & ~E_DEPRECATED
 ; http://php.net/error-reporting
 ;error_reporting = E_ALL & ~E_DEPRECATED
-error_reporting = -1
+error_reporting = E_ALL & ~E_DEPRECATED
 
 ; This directive controls whether or not and where PHP will output errors,
 ; notices and warnings too. Error output is very useful during development, but

--- a/pgo/tpl/php/php-8.4-pgo-nts.ini
+++ b/pgo/tpl/php/php-8.4-pgo-nts.ini
@@ -512,7 +512,7 @@ memory_limit = 128M
 ; Production Value: E_ALL & ~E_DEPRECATED
 ; http://php.net/error-reporting
 ;error_reporting = E_ALL & ~E_DEPRECATED
-error_reporting = -1
+error_reporting = E_ALL & ~E_DEPRECATED
 
 ; This directive controls whether or not and where PHP will output errors,
 ; notices and warnings too. Error output is very useful during development, but

--- a/pgo/tpl/php/php-8.4-pgo-ts-cache.ini
+++ b/pgo/tpl/php/php-8.4-pgo-ts-cache.ini
@@ -512,7 +512,7 @@ memory_limit = 128M
 ; Production Value: E_ALL & ~E_DEPRECATED
 ; http://php.net/error-reporting
 ;error_reporting = E_ALL & ~E_DEPRECATED
-error_reporting = -1
+error_reporting = E_ALL & ~E_DEPRECATED
 
 ; This directive controls whether or not and where PHP will output errors,
 ; notices and warnings too. Error output is very useful during development, but

--- a/pgo/tpl/php/php-8.4-pgo-ts.ini
+++ b/pgo/tpl/php/php-8.4-pgo-ts.ini
@@ -512,7 +512,7 @@ memory_limit = 128M
 ; Production Value: E_ALL & ~E_DEPRECATED
 ; http://php.net/error-reporting
 ;error_reporting = E_ALL & ~E_DEPRECATED
-error_reporting = -1
+error_reporting = E_ALL & ~E_DEPRECATED
 
 ; This directive controls whether or not and where PHP will output errors,
 ; notices and warnings too. Error output is very useful during development, but


### PR DESCRIPTION
PGO optimization is meant for production, so we should use the recommended `error_reporting` setting for such environments.  This is especially relevant since PHP is deprecating lots of stuff, and we do not want to optimize any code paths which are triggered by deprecation notices.

Of course, individual apps may override that, but choosing a reasonable default is a first step.