### PR TITLE
Bail out after download retries exhausted

### DIFF
--- a/lib/php/libsdk/SDK/Build/Dependency/Fetcher.php
+++ b/lib/php/libsdk/SDK/Build/Dependency/Fetcher.php
@@ -61,6 +61,8 @@ retry:
 				sleep(1);
 				$retries--;
 				goto retry;
+			} else {
+				throw $e;
 			}
 		}
 


### PR DESCRIPTION
Otherwise, this will result in false successes and cause build problems later on

fixes #44